### PR TITLE
Updated background image in light mode fix #74

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,6 +15,8 @@ body {
     45deg,
     rgba(255, 166, 10, 1) 24%,
     rgba(255, 0, 224, 1) 100%
+   background-image: url(https://user-images.githubusercontent.com/72564975/112663760-32405600-8e7f-11eb-8131-d8c8accf605c.jpg);
+
   );
   align-self: center;
   -webkit-background-clip: text;
@@ -65,6 +67,7 @@ input {
 
 .dark_input {
   background-color: rgb(140, 140, 140);
+  background-image: url(https://user-images.githubusercontent.com/72564975/112664271-cad6d600-8e7f-11eb-93c1-7c59b3329c49.jpg);
 }
 .loading {
   position: fixed;

--- a/src/App.css
+++ b/src/App.css
@@ -15,7 +15,6 @@ body {
     45deg,
     rgba(255, 166, 10, 1) 24%,
     rgba(255, 0, 224, 1) 100%
-   background-image: url(https://user-images.githubusercontent.com/72564975/112663760-32405600-8e7f-11eb-8131-d8c8accf605c.jpg);
 
   );
   align-self: center;
@@ -67,7 +66,6 @@ input {
 
 .dark_input {
   background-color: rgb(140, 140, 140);
-  background-image: url(https://user-images.githubusercontent.com/72564975/112664271-cad6d600-8e7f-11eb-93c1-7c59b3329c49.jpg);
 }
 .loading {
   position: fixed;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background-image:url("https://i.redd.it/qwd83nc4xxf41.jpg");
+  background-image:url("https://user-images.githubusercontent.com/72564975/112663760-32405600-8e7f-11eb-8131-d8c8accf605c.jpg");
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
@@ -9,7 +9,7 @@ body {
 }
 
 body.dark-bg {
-  background-image: url("https://i.pinimg.com/originals/85/ec/df/85ecdf1c3611ecc9b7fa85282d9526e0.jpg");
+  background-image: url("https://user-images.githubusercontent.com/72564975/112664271-cad6d600-8e7f-11eb-93c1-7c59b3329c49.jpg");
 }
 
 code {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  background-image:url("https://user-images.githubusercontent.com/72564975/112663760-32405600-8e7f-11eb-8131-d8c8accf605c.jpg");
+  background-image:url("https://user-images.githubusercontent.com/72564975/112664111-9b27ce00-8e7f-11eb-957f-3add5deca3dc.jpg");
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
@@ -9,7 +9,7 @@ body {
 }
 
 body.dark-bg {
-  background-image: url("https://user-images.githubusercontent.com/72564975/112664271-cad6d600-8e7f-11eb-93c1-7c59b3329c49.jpg");
+  background-image: url("https://i.pinimg.com/originals/85/ec/df/85ecdf1c3611ecc9b7fa85282d9526e0.jpg");
 }
 
 code {


### PR DESCRIPTION
Updated background image in light mode as before the background image was a bit loud in light mode.
Before
![Messenger - Google Chrome 03-04-2021 15_40_42 (2)](https://user-images.githubusercontent.com/72564975/113475926-c8830600-9495-11eb-820a-6bc12694ac2b.png)
After
![Messenger - Google Chrome 03-04-2021 11_34_49 (2)](https://user-images.githubusercontent.com/72564975/113475936-d173d780-9495-11eb-8536-285c3b9165de.png)
Please review and merge this pr. Thank you @DhairyaBahl 