### PR TITLE
Welcome Dialogue Box Submits on Pressing Enter Key

### DIFF
--- a/src/WelcomeDialogBox.js
+++ b/src/WelcomeDialogBox.js
@@ -40,6 +40,7 @@ export default function WelcomeDialogBox(props) {
             label="Name"
             fullWidth
             onChange={(e) => setName(e.target.value)}
+            onKeyPress={(e) => { if(e.key==='Enter') enterName() }}
             inputProps={{
               style: { borderRadius: "0px" }
             }}


### PR DESCRIPTION
## Fixes #271 

Now a user can press enter after typing in his/her name, and it will automatically set the name, and close the dialogue box, just like on clicking the Enter button.

(Screenshot not possible as it's not possible to show enter key being pressed)