### PR TITLE
Load Latest 50 Messages only at the Start

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -50,9 +50,10 @@ function App() {
    setLoading(true)
    console.log("setting true",loading)
    db.collection("messages")
-     .orderBy("timestamp", "asc")
+     .orderBy("timestamp", "desc")
+     .limit(50)
      .onSnapshot((snapshot) =>{
-       setMessages(snapshot.docs.map((doc) => doc.data()));
+       setMessages((snapshot.docs.map((doc) => doc.data())).reverse());
        setLoading(false)
      });
  }, []);


### PR DESCRIPTION
## Fixes #276 

### Screenshot:
(the top most message is 50th when ordered from latest to oldest, and the scrollbar thumb is noticeable larger now)
![image](https://user-images.githubusercontent.com/68962290/118716515-c4a70b00-b7d9-11eb-96c6-5be51347e1a9.png)
