### PR TITLE
Implemented Load Older Messages Button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -243,7 +243,6 @@
   border: 1px solid white;
  }
   
-}
 
 .dark_input {
   background-color: transparent;
@@ -548,5 +547,16 @@
  }
  .scrollicon {
   color: rgb(255, 255, 255);
+ }
+
+ .loadOlderMessages {
+  margin: 0 auto;
+  background-color: rgb(0, 50, 77);
+  color: white;
+  cursor: pointer;
+  border-radius: 50px;
+	border: none;
+	padding: 10px 20px;
+	font-size: 2rem;
  }
  

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,8 @@ function App() {
  const [showEmojis, setshowEmojis] = useState(false);
  const { finalTranscript,resetTranscript } = useSpeechRecognition();
  const [showAlert, setShowAlert] = useState(false);
- 
+ const [messageCount, setMessageCount] = useState(50);
+ const [scrollTop, setScrollTop] = useState(false);
  
  useEffect(() => {
    setOpenWelcomeDialogBox(true);
@@ -52,16 +53,19 @@ function App() {
    console.log("setting true",loading)
    db.collection("messages")
      .orderBy("timestamp", "desc")
-     .limit(50)
+     .limit(messageCount)
      .onSnapshot((snapshot) =>{
        setMessages((snapshot.docs.map((doc) => doc.data())).reverse());
        setLoading(false)
      });
- }, []);
- 
+   setScrollTop(true);
+ }, [messageCount]);
+
  useEffect(() => {
+   if(scrollTop) return setScrollTop(false);
    scrollToBottom();
- }, [messages]);
+  }, [messages]);
+
   const handleClick = () => setClick(!click);
 
   const scrollToBottom = () => {
@@ -122,7 +126,9 @@ function App() {
      console.log("picker visible");
    }
  };
- 
+ const loadOlderMessages = () => {
+   setMessageCount(prev => prev+50);
+ };
  useEffect(() => {
    if(finalTranscript !== "")
    {
@@ -267,6 +273,7 @@ function App() {
                <br />
                <br />
                <br />
+               <button className="loadOlderMessages" onClick={loadOlderMessages}>Load Older Messages</button>
                <br />
                <br />
                {messages.map((message) => (


### PR DESCRIPTION
## Fixes #282 

## Changes made:
- Implemented a button which increments total message count by 50 each time it is clicked.
- Used this message count variable as a dependency when fetching from firestore
- Styled the button.
- Made it so that when older messages are loaded, the page is not scrolled to bottom, but scrolled to top instead for better UX.

## Screenshot:
![image](https://user-images.githubusercontent.com/68962290/118883424-128b4400-b8aa-11eb-87c0-1ca46d53be4f.png)
