### PR TITLE
Added Local Storage for user details & preferences

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import SpeechRecognition, {
     useSpeechRecognition
 } from "react-speech-recognition";
 import Login from "./components/login/login";
+import useLocalStorage from "./customHooks/useLocalStorage";
 
 // import About from "./components/about-us/About";
 // import Footer from "./components/footer/footer";
@@ -41,10 +42,10 @@ function App() {
     const [loading, setLoading] = useState(false);
     const [input, setInput] = useState("");
     const [messages, setMessages] = useState([]);
-    const [username, setUsername] = useState("");
-    const [uid, setUid] = useState("");
+    const [username, setUsername] = useLocalStorage("username", "");
+    const [uid, setUid] = useLocalStorage("uid", "");
     const [openWelcomeDialogBox, setOpenWelcomeDialogBox] = useState(false);
-    const [dark, setDark] = useState(false);
+    const [dark, setDark] = useLocalStorage("dark", false);
     const messagesEndRef = useRef(null);
     const inputElement = useRef(null);
     const [click, setClick] = useState(false);
@@ -55,6 +56,7 @@ function App() {
     const [scrollTop, setScrollTop] = useState(false);
 
     useEffect(() => {
+        if(!username || !uid)
         setOpenWelcomeDialogBox(true);
     }, []);
 

--- a/src/customHooks/useLocalStorage.js
+++ b/src/customHooks/useLocalStorage.js
@@ -1,0 +1,14 @@
+import { useState, useEffect } from 'react'
+
+export default function useLocalStorage(name, initialValue) {
+    const PREFIX = "RMA"
+    const key = `${PREFIX}-${name}`
+    
+    const [value, setValue] = useState(JSON.parse(localStorage.getItem(key)) || initialValue)
+
+    useEffect(() => {
+        localStorage.setItem(key, JSON.stringify(value))
+    }, [value])
+
+    return [value, setValue]
+}


### PR DESCRIPTION
## Fixes #319 

## Changes made in Code:
- Created a new re-usable custom hook `useLocalStorage`
- Used this new hook instead of `useState` for persisting certain user data

## Changes in UX
- Now the user will not have to enter his name and be treated like a brand new user everytime he/she uses this website
- The website will "remember" the user after the 1st visit