### PR TITLE
Fix nav links for dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -61,7 +61,7 @@ body {
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 2rem;
+  font-size: 1.6rem;
   position: sticky;
   top: 0;
   z-index: 20;


### PR DESCRIPTION
FIXES #383 
Made size same for nav links in dark mode as well.
![image](https://user-images.githubusercontent.com/77333275/119533283-4fbc6e00-bda3-11eb-8dd1-ebb93526e5ae.png)
